### PR TITLE
Change Show Toolbox shortcut to Shift+t

### DIFF
--- a/krita-redesign/nuTools/nutools.action
+++ b/krita-redesign/nuTools/nutools.action
@@ -11,7 +11,7 @@
         <iconText>nT</iconText>
         <activationFlags>0</activationFlags>
         <activationConditions>0</activationConditions>
-        <shortcut>t</shortcut>
+        <shortcut>shift+t</shortcut>
         <isCheckable>true</isCheckable>
         <statusTip></statusTip>
         </Action>


### PR DESCRIPTION
The Show Toolbox shortcut `t` conflicts with the default Move Tool shortcut `t`.
Nothing happens when `t` is pressed.
`Shift+t` is available.