### PR TITLE
Fix style application to local to canvas/doc area

### DIFF
--- a/krita-redesign/redesign.py
+++ b/krita-redesign/redesign.py
@@ -167,9 +167,7 @@ class Redesign(Extension):
             full_style_sheet += f"\n {variables.flat_menu_bar_style} \n"
             full_style_sheet += f"\n {variables.flat_combo_box_style} \n"
             full_style_sheet += f"\n {variables.flat_status_bar_style} \n"
-            full_style_sheet += f"\n {variables.flat_tab_base_style} \n"
             full_style_sheet += f"\n {variables.flat_tree_view_style} \n"
-            full_style_sheet += f"\n {variables.flat_tab_base_style} \n"
 
         # Toolbar
         if self.usesFlatTheme:
@@ -190,12 +188,16 @@ class Redesign(Extension):
         if self.usesFlatTheme:
             overview_style += f"\n {variables.flat_overview_docker_style} \n"
 
-        overview.setStyleSheet(overview_style)
+        if overview:
+            overview.setStyleSheet(overview_style)
 
         # For document tab
         canvas_style_sheet = ""
 
         if self.usesFlatTheme:
+            # Keep tab styling local to the canvas/doc area. Applying it
+            # globally affects dock/tab containers in Krita 5+.
+            canvas_style_sheet += f"\n {variables.flat_tab_base_style} \n"
             if self.usesThinDocumentTabs:
                 canvas_style_sheet += f"\n {variables.flat_tab_small_style} \n"
             else: 


### PR DESCRIPTION
Unsure if this is wanted, but it fixes the style application by turning it to a more localised application over a global one.

Before:
<img width="2386" height="1584" alt="Image" src="https://github.com/user-attachments/assets/2dd0253b-9134-4b6f-ad6c-0c2c4f587530" />

After:
<img width="2386" height="1584" alt="Image" src="https://github.com/user-attachments/assets/8dc7778c-f8b2-4eb6-b3b8-72f40995298e" />
